### PR TITLE
ワークフローでKEYをファイル名から取得するように修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,8 @@ jobs:
           if [ -n "$file" ] && [ -f "$file" ]; then
             echo "Processing file: $file"
             
-            KEY=$(jq -r '.key // empty' "$file")
+            # ファイル名からKEYを取得（例: suuji/0-999/0-99/2.json -> 2）
+            KEY=$(basename "$file" .json)
             DESCRIPTION=$(jq -r '.description // ""' "$file")
             
             if [ -n "$KEY" ]; then


### PR DESCRIPTION
## 概要
GitHub ActionsワークフローでJSONファイルのKEYを取得する方法を修正しました。

## 変更内容
- JSONファイルの`key`フィールドではなく、ファイル名からKEYを取得するように変更
- `basename`コマンドを使用してファイル名（拡張子除く）をKEYとして使用
- `2.json`のようなファイル構造に対応

## 変更理由
現在のJSONファイル構造（`2.json`など）では`key`フィールドが存在せず、`number`フィールドのみが存在するため、ファイル名から数字を取得する方式に変更しました。

## 影響範囲
- GitHub Actionsワークフローの動作
- Firestoreへのデータ送信処理

## テスト
- `2.json`ファイルでテスト済み
- ファイル名から正しくKEY（`2`）が取得されることを確認