### PR TITLE
fix: GitHub ActionsワークフローのJSON送信時の改行文字問題を修正

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,14 @@ jobs:
             if [ -n "$KEY" ]; then
               echo "Processing key: $KEY with description: $DESCRIPTION"
               
+              # jqを使って適切にJSONを構築
+              JSON_PAYLOAD=$(jq -n --arg key "$KEY" --arg description "$DESCRIPTION" '{key: ($key | tonumber), description: $description}')
+              
               # HandleNumber APIを呼び出し（サービスアカウント認証）
               curl -X POST "${{ secrets.SUUJI_HANDLE_NUMBER_API_URL_DEV }}" \
                 -H "Content-Type: application/json" \
                 -H "Authorization: Bearer ${{ secrets.FIREBASE_FUNCTIONS_SERVICE_ACCOUNT }}" \
-                -d "{\"key\": $KEY, \"description\": \"$DESCRIPTION\"}" \
+                -d "$JSON_PAYLOAD" \
                 --fail-with-body
               
               echo "Successfully processed key: $KEY"


### PR DESCRIPTION
## 概要
GitHub ActionsワークフローでJSONファイルを処理する際に、改行文字を含むdescriptionフィールドが原因でAPIリクエストが失敗する問題を修正しました。

## 問題
- `curl`コマンドで手動でJSONを構築していたため、改行文字（`\n`）が含まれるdescriptionフィールドでJSONが壊れていた
- エラーメッセージ: `invalid json body`、`curl: (22) The requested URL returned error: 400`

## 修正内容
- `jq`を使用してJSONペイロードを適切に構築するように変更
- `--arg`オプションを使用して改行文字を含む文字列を安全にJSONに埋め込み
- キーを文字列から数値に適切に変換

## 変更ファイル
- `.github/workflows/main.yml`

## テスト
修正後のワークフローが正常に動作することを確認する必要があります。