### PR TITLE
fix: Firebase Functionsの不要な認証ヘッダーを削除

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,9 @@ jobs:
               # jqを使って適切にJSONを構築
               JSON_PAYLOAD=$(jq -n --arg key "$KEY" --arg description "$DESCRIPTION" '{key: ($key | tonumber), description: $description}')
               
-              # HandleNumber APIを呼び出し（サービスアカウント認証）
+              # HandleNumber APIを呼び出し
               curl -X POST "${{ secrets.SUUJI_HANDLE_NUMBER_API_URL_DEV }}" \
                 -H "Content-Type: application/json" \
-                -H "Authorization: Bearer ${{ secrets.FIREBASE_FUNCTIONS_SERVICE_ACCOUNT }}" \
                 -d "$JSON_PAYLOAD" \
                 --fail-with-body
               


### PR DESCRIPTION
## 概要
Firebase Functionsの`HandleNumber`関数は認証不要のため、不要な`Authorization`ヘッダーを削除してワークフローを修正しました。

## 問題
- 前回の修正でJSONの構築は解決したが、不要な認証ヘッダーが原因で追加のエラーが発生していた
- `Authorization: Bearer`ヘッダーを送信しようとして認証エラーが発生

## 修正内容
- Firebase Functionsの`HandleNumber`関数を確認したところ、認証は必要ないことが判明
- 不要な`Authorization: Bearer`ヘッダーを削除
- シンプルなPOSTリクエストでAPIを呼び出すように修正

## 変更ファイル
- `.github/workflows/main.yml`

## テスト
修正後のワークフローが正常に動作することを確認する必要があります。